### PR TITLE
fixing a null pointer exception when apply features-javac to itself

### DIFF
--- a/src/main/java/uk/ac/cam/acr31/features/javac/syntactic/LastLexicalUseScanner.java
+++ b/src/main/java/uk/ac/cam/acr31/features/javac/syntactic/LastLexicalUseScanner.java
@@ -65,7 +65,8 @@ public class LastLexicalUseScanner extends TreeScanner<Void, Void> {
   @Override
   public Void visitIdentifier(IdentifierTree node, Void aVoid) {
     var ident = (JCTree.JCIdent) node;
-    symbolMap.put(ident.sym, node);
+    if (ident.sym != null)
+       symbolMap.put(ident.sym, node);
     return super.visitIdentifier(node, aVoid);
   }
 }


### PR DESCRIPTION
Applying the javac plugin to compile the project itself, it turns out there was a NullPointer exception when calling "maven install". This can be overcome by skipping the symbol when it is null.