### PR TITLE
Type nodes and assignability analysis

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,6 +169,7 @@
                         <include>src/**/*</include>
                     </includes>
                     <excludes>
+                        <exclude>src/main/java/uk/ac/cam/acr31/features/javac/semantic/AssignabilityAnalysis.java</exclude>
                         <exclude>src/main/java/uk/ac/cam/acr31/features/javac/semantic/TypeAnalysis.java</exclude>
                         <exclude>src/main/java/uk/ac/cam/acr31/features/javac/semantic/TypeScanner.java</exclude>
                     </excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -172,6 +172,7 @@
                         <exclude>src/main/java/uk/ac/cam/acr31/features/javac/semantic/AssignabilityAnalysis.java</exclude>
                         <exclude>src/main/java/uk/ac/cam/acr31/features/javac/semantic/TypeAnalysis.java</exclude>
                         <exclude>src/main/java/uk/ac/cam/acr31/features/javac/semantic/TypeScanner.java</exclude>
+                        <exclude>src/test/java/uk/ac/cam/acr31/features/javac/AssignabilityAnalysisTest.java</exclude>
                         <exclude>src/test/java/uk/ac/cam/acr31/features/javac/TypeScannerTest.java</exclude>
                     </excludes>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -172,6 +172,7 @@
                         <exclude>src/main/java/uk/ac/cam/acr31/features/javac/semantic/AssignabilityAnalysis.java</exclude>
                         <exclude>src/main/java/uk/ac/cam/acr31/features/javac/semantic/TypeAnalysis.java</exclude>
                         <exclude>src/main/java/uk/ac/cam/acr31/features/javac/semantic/TypeScanner.java</exclude>
+                        <exclude>src/test/java/uk/ac/cam/acr31/features/javac/TypeScannerTest.java</exclude>
                     </excludes>
                 </configuration>
                 <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -168,6 +168,10 @@
                     <includes>
                         <include>src/**/*</include>
                     </includes>
+                    <excludes>
+                        <exclude>src/main/java/uk/ac/cam/acr31/features/javac/semantic/TypeAnalysis.java</exclude>
+                        <exclude>src/main/java/uk/ac/cam/acr31/features/javac/semantic/TypeScanner.java</exclude>
+                    </excludes>
                 </configuration>
                 <executions>
                     <execution>

--- a/src/main/java/uk/ac/cam/acr31/features/javac/FeaturePlugin.java
+++ b/src/main/java/uk/ac/cam/acr31/features/javac/FeaturePlugin.java
@@ -43,6 +43,8 @@ import uk.ac.cam.acr31.features.javac.proto.GraphProtos.FeatureEdge.EdgeType;
 import uk.ac.cam.acr31.features.javac.proto.GraphProtos.FeatureNode;
 import uk.ac.cam.acr31.features.javac.proto.GraphProtos.FeatureNode.NodeType;
 import uk.ac.cam.acr31.features.javac.semantic.DataflowOutputs;
+import uk.ac.cam.acr31.features.javac.semantic.TypeAnalysis;
+import uk.ac.cam.acr31.features.javac.semantic.TypeScanner;
 import uk.ac.cam.acr31.features.javac.syntactic.ComputedFromScanner;
 import uk.ac.cam.acr31.features.javac.syntactic.FormalArgScanner;
 import uk.ac.cam.acr31.features.javac.syntactic.GuardedByScanner;
@@ -146,6 +148,9 @@ public class FeaturePlugin implements Plugin {
     JavacProcessingEnvironment processingEnvironment = JavacProcessingEnvironment.instance(context);
     var analysisResults = DataflowOutputs.create(compilationUnit, processingEnvironment);
     DataflowOutputsScanner.addToGraph(compilationUnit, analysisResults, featureGraph);
+
+    var typeAnalysis = new TypeAnalysis(compilationUnit, processingEnvironment);
+    TypeScanner.addToGraph(compilationUnit, featureGraph, typeAnalysis);
 
     ComputedFromScanner.addToGraph(compilationUnit, featureGraph);
     LastLexicalUseScanner.addToGraph(compilationUnit, featureGraph);

--- a/src/main/java/uk/ac/cam/acr31/features/javac/FeaturePlugin.java
+++ b/src/main/java/uk/ac/cam/acr31/features/javac/FeaturePlugin.java
@@ -42,6 +42,7 @@ import uk.ac.cam.acr31.features.javac.proto.GraphProtos.FeatureEdge;
 import uk.ac.cam.acr31.features.javac.proto.GraphProtos.FeatureEdge.EdgeType;
 import uk.ac.cam.acr31.features.javac.proto.GraphProtos.FeatureNode;
 import uk.ac.cam.acr31.features.javac.proto.GraphProtos.FeatureNode.NodeType;
+import uk.ac.cam.acr31.features.javac.semantic.AssignabilityAnalysis;
 import uk.ac.cam.acr31.features.javac.semantic.DataflowOutputs;
 import uk.ac.cam.acr31.features.javac.semantic.TypeAnalysis;
 import uk.ac.cam.acr31.features.javac.semantic.TypeScanner;
@@ -151,6 +152,7 @@ public class FeaturePlugin implements Plugin {
 
     var typeAnalysis = new TypeAnalysis(compilationUnit, processingEnvironment);
     TypeScanner.addToGraph(compilationUnit, featureGraph, typeAnalysis);
+    AssignabilityAnalysis.addToGraph(featureGraph, typeAnalysis);
 
     ComputedFromScanner.addToGraph(compilationUnit, featureGraph);
     LastLexicalUseScanner.addToGraph(compilationUnit, featureGraph);

--- a/src/main/java/uk/ac/cam/acr31/features/javac/graph/DotOutput.java
+++ b/src/main/java/uk/ac/cam/acr31/features/javac/graph/DotOutput.java
@@ -147,6 +147,9 @@ public class DotOutput {
       case HAS_TYPE:
         ports = "headport=e, tailport=w, color=grey, weight=0";
         break;
+      case ASSIGNABLE_TO:
+        ports = "headport=e, tailport=w, color=brown, weight=0";
+        break;
       default:
         ports = "";
     }

--- a/src/main/java/uk/ac/cam/acr31/features/javac/graph/DotOutput.java
+++ b/src/main/java/uk/ac/cam/acr31/features/javac/graph/DotOutput.java
@@ -63,6 +63,9 @@ public class DotOutput {
       Set<FeatureNode> tokenSet = graph.tokens();
       writeSubgraph(w, tokenSet, "max", verboseDot);
 
+      Set<FeatureNode> typeSet = graph.types();
+      writeSubgraph(w, typeSet, "min", verboseDot);
+
       for (FeatureEdge edge : graph.edges()) {
         w.println(dotEdge(edge, graph.incidentNodes(edge)));
       }
@@ -140,6 +143,9 @@ public class DotOutput {
         } else {
           ports = "";
         }
+        break;
+      case HAS_TYPE:
+        ports = "headport=e, tailport=w, color=grey, weight=0";
         break;
       default:
         ports = "";

--- a/src/main/java/uk/ac/cam/acr31/features/javac/graph/FeatureGraph.java
+++ b/src/main/java/uk/ac/cam/acr31/features/javac/graph/FeatureGraph.java
@@ -124,6 +124,10 @@ public class FeatureGraph {
     }
   }
 
+  public TypeMirror lookupTypeMirror(FeatureNode node) {
+    return typeToNodeMap.inverse().get(node);
+  }
+
   public FeatureNode createFeatureNodeForType(Types types, NodeType nodeType, TypeMirror type) {
     if (typeToNodeMap.containsKey(type)) {
       return typeToNodeMap.get(type);

--- a/src/main/java/uk/ac/cam/acr31/features/javac/semantic/AssignabilityAnalysis.java
+++ b/src/main/java/uk/ac/cam/acr31/features/javac/semantic/AssignabilityAnalysis.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2019 Henry Mercer (henry.mercer@me.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.ac.cam.acr31.features.javac.semantic;
+
+import javax.lang.model.type.TypeMirror;
+import uk.ac.cam.acr31.features.javac.graph.FeatureGraph;
+import uk.ac.cam.acr31.features.javac.proto.GraphProtos;
+
+public class AssignabilityAnalysis {
+  private final FeatureGraph graph;
+  private final TypeAnalysis analysis;
+
+  public AssignabilityAnalysis(FeatureGraph graph, TypeAnalysis analysis) {
+    this.graph = graph;
+    this.analysis = analysis;
+  }
+
+  public static void addToGraph(FeatureGraph graph, TypeAnalysis analysis) {
+    AssignabilityAnalysis assignabilityAnalysis = new AssignabilityAnalysis(graph, analysis);
+    assignabilityAnalysis.performAnalysis();
+  }
+
+  private void performAnalysis() {
+    for (GraphProtos.FeatureNode typeNode : graph.types()) {
+      TypeMirror type = graph.lookupTypeMirror(typeNode);
+      if (type == null) {
+        continue;
+      }
+      for (GraphProtos.FeatureNode assignToTypeNode : graph.types()) {
+        TypeMirror assignToType = graph.lookupTypeMirror(assignToTypeNode);
+        if (assignToType == null || analysis.getTypes().isSameType(type, assignToType)) {
+          continue;
+        }
+
+        if (analysis.getTypes().isAssignable(type, assignToType)) {
+          graph.addEdge(typeNode, assignToTypeNode, GraphProtos.FeatureEdge.EdgeType.ASSIGNABLE_TO);
+        }
+      }
+    }
+  }
+}

--- a/src/main/java/uk/ac/cam/acr31/features/javac/semantic/AssignabilityAnalysis.java
+++ b/src/main/java/uk/ac/cam/acr31/features/javac/semantic/AssignabilityAnalysis.java
@@ -46,7 +46,7 @@ public class AssignabilityAnalysis {
           continue;
         }
 
-        if (analysis.getTypes().isAssignable(type, assignToType)) {
+        if (analysis.isAssignable(type, assignToType)) {
           graph.addEdge(typeNode, assignToTypeNode, GraphProtos.FeatureEdge.EdgeType.ASSIGNABLE_TO);
         }
       }

--- a/src/main/java/uk/ac/cam/acr31/features/javac/semantic/TypeAnalysis.java
+++ b/src/main/java/uk/ac/cam/acr31/features/javac/semantic/TypeAnalysis.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2019 Henry Mercer (henry.mercer@me.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.ac.cam.acr31.features.javac.semantic;
+
+import com.sun.source.tree.CompilationUnitTree;
+import com.sun.source.tree.Tree;
+import com.sun.source.util.TreePath;
+import com.sun.source.util.Trees;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.Types;
+
+public class TypeAnalysis {
+
+    private final CompilationUnitTree compilationUnitTree;
+    private final ProcessingEnvironment processingEnvironment;
+
+    public TypeAnalysis(
+        CompilationUnitTree compilationUnitTree, ProcessingEnvironment processingEnvironment) {
+        this.compilationUnitTree = compilationUnitTree;
+        this.processingEnvironment = processingEnvironment;
+    }
+
+    public TypeMirror getTypeMirror(Tree typeDecl) {
+        Trees trees = Trees.instance(processingEnvironment);
+        TreePath path = TreePath.getPath(compilationUnitTree, typeDecl);
+        return trees.getTypeMirror(path);
+    }
+
+    /**
+     * Returns true if typeA is assignable to typeB.
+     */
+    public boolean isAssignable(Tree typeA, Tree typeB) {
+        TypeMirror typeAMirror = getTypeMirror(typeA);
+        TypeMirror typeBMirror = getTypeMirror(typeB);
+
+        if (typeAMirror == null || typeBMirror == null) {
+            return false;
+        }
+        return processingEnvironment.getTypeUtils().isAssignable(typeAMirror, typeBMirror);
+    }
+
+    public String getApproxTypeName(Tree tree) {
+        return getTypeMirror(tree).toString();
+    }
+
+    public Types getTypes() {
+        return processingEnvironment.getTypeUtils();
+    }
+}

--- a/src/main/java/uk/ac/cam/acr31/features/javac/semantic/TypeAnalysis.java
+++ b/src/main/java/uk/ac/cam/acr31/features/javac/semantic/TypeAnalysis.java
@@ -21,6 +21,7 @@ import com.sun.source.tree.Tree;
 import com.sun.source.util.TreePath;
 import com.sun.source.util.Trees;
 import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Types;
 
@@ -41,17 +42,19 @@ public class TypeAnalysis {
         return trees.getTypeMirror(path);
     }
 
+    private boolean canCheckAssignability(TypeMirror type) {
+        return type.getKind() != TypeKind.EXECUTABLE && type.getKind() != TypeKind.PACKAGE;
+    }
+
     /**
      * Returns true if typeA is assignable to typeB.
      */
-    public boolean isAssignable(Tree typeA, Tree typeB) {
-        TypeMirror typeAMirror = getTypeMirror(typeA);
-        TypeMirror typeBMirror = getTypeMirror(typeB);
-
-        if (typeAMirror == null || typeBMirror == null) {
+    public boolean isAssignable(TypeMirror typeA, TypeMirror typeB) {
+        if (!canCheckAssignability(typeA) || !canCheckAssignability(typeB)) {
             return false;
         }
-        return processingEnvironment.getTypeUtils().isAssignable(typeAMirror, typeBMirror);
+
+        return processingEnvironment.getTypeUtils().isAssignable(typeA, typeB);
     }
 
     public String getApproxTypeName(Tree tree) {

--- a/src/main/java/uk/ac/cam/acr31/features/javac/semantic/TypeScanner.java
+++ b/src/main/java/uk/ac/cam/acr31/features/javac/semantic/TypeScanner.java
@@ -62,7 +62,7 @@ public class TypeScanner extends TreeScanner<Void, Void> {
 
   @Override
   public Void visitVariable(VariableTree tree, Void ignored) {
-    addTypeEdge(tree.getNameExpression());
+    addTypeEdge(tree.getType());
     addTypeEdge(tree.getInitializer());
     return super.visitVariable(tree, ignored);
   }

--- a/src/main/java/uk/ac/cam/acr31/features/javac/semantic/TypeScanner.java
+++ b/src/main/java/uk/ac/cam/acr31/features/javac/semantic/TypeScanner.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2019 Henry Mercer (henry.mercer@me.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.ac.cam.acr31.features.javac.semantic;
+
+import com.sun.source.tree.CompilationUnitTree;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.source.util.TreeScanner;
+import uk.ac.cam.acr31.features.javac.graph.FeatureGraph;
+import uk.ac.cam.acr31.features.javac.proto.GraphProtos;
+
+public class TypeScanner extends TreeScanner<Void, Void> {
+  private final FeatureGraph graph;
+  private final TypeAnalysis typeAnalysis;
+
+  public TypeScanner(FeatureGraph graph, TypeAnalysis typeAnalysis) {
+    this.graph = graph;
+    this.typeAnalysis = typeAnalysis;
+  }
+
+  public static void addToGraph(
+      CompilationUnitTree compilationUnitTree, FeatureGraph graph, TypeAnalysis typeAnalysis) {
+    TypeScanner typeScanner = new TypeScanner(graph, typeAnalysis);
+    compilationUnitTree.accept(typeScanner, null);
+  }
+
+  @Override
+  public Void visitMethodInvocation(MethodInvocationTree tree, Void ignored) {
+    for (ExpressionTree argTree : tree.getArguments()) {
+      GraphProtos.FeatureNode argNode = graph.lookupNode(argTree);
+      if (argNode != null) {
+        // Do we need TypeAnalysis?
+        GraphProtos.FeatureNode typeNode = graph.createFeatureNodeForType(
+            typeAnalysis.getTypes(),
+            GraphProtos.FeatureNode.NodeType.TYPE,
+            typeAnalysis.getTypeMirror(argTree)
+        );
+        if (typeNode != null) {
+          graph.addEdge(argNode, typeNode, GraphProtos.FeatureEdge.EdgeType.HAS_TYPE);
+        }
+      }
+    }
+    return super.visitMethodInvocation(tree, ignored);
+  }
+}

--- a/src/main/java/uk/ac/cam/acr31/features/javac/testing/FeatureGraphChecks.java
+++ b/src/main/java/uk/ac/cam/acr31/features/javac/testing/FeatureGraphChecks.java
@@ -18,10 +18,12 @@ package uk.ac.cam.acr31.features.javac.testing;
 
 import com.google.common.collect.Sets;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import uk.ac.cam.acr31.features.javac.graph.FeatureGraph;
+import uk.ac.cam.acr31.features.javac.proto.GraphProtos;
 import uk.ac.cam.acr31.features.javac.proto.GraphProtos.FeatureEdge;
 import uk.ac.cam.acr31.features.javac.proto.GraphProtos.FeatureEdge.EdgeType;
 import uk.ac.cam.acr31.features.javac.proto.GraphProtos.FeatureNode;
@@ -32,18 +34,22 @@ public class FeatureGraphChecks {
     return graph.findNode(span.start(), span.end());
   }
 
+  private static Optional<FeatureEdge> anyEdgeBetween(
+      FeatureGraph graph, FeatureNode source, FeatureNode destination, EdgeType edgeType) {
+    return graph
+        .edges(source, destination)
+        .stream()
+        .filter(e -> e.getType().equals(edgeType))
+        .findAny();
+  }
+
   public static FeatureEdge edgeBetween(
       FeatureGraph graph, SourceSpan source, SourceSpan destination, EdgeType edgeType) {
     Set<FeatureNode> sourceNodes = findNodes(graph, source);
     Set<FeatureNode> destinationNodes = findNodes(graph, destination);
     for (FeatureNode sourceNode : sourceNodes) {
       for (FeatureNode destinationNode : destinationNodes) {
-        Optional<FeatureEdge> edge =
-            graph
-                .edges(sourceNode, destinationNode)
-                .stream()
-                .filter(e -> e.getType().equals(edgeType))
-                .findAny();
+        Optional<FeatureEdge> edge = anyEdgeBetween(graph, sourceNode, destinationNode, edgeType);
         if (edge.isPresent()) {
           return edge.get();
         }
@@ -51,6 +57,11 @@ public class FeatureGraphChecks {
     }
     throw new AssertionError(
         "Failed to find an edge from " + source + " to " + destination + " with type " + edgeType);
+  }
+
+  public static boolean isEdgeBetween(
+      FeatureGraph graph, FeatureNode source, FeatureNode destination, EdgeType edgeType) {
+    return anyEdgeBetween(graph, source, destination, edgeType).isPresent();
   }
 
   public static boolean isAcyclic(FeatureGraph graph, EdgeType edgeType) {
@@ -86,5 +97,19 @@ public class FeatureGraphChecks {
       // remove one leaf and repeat
       nodes.remove(possibleLeaf.get());
     }
+  }
+
+  public static GraphProtos.FeatureNode findAssociatedTypeNode(FeatureGraph graph, SourceSpan span) {
+    for (GraphProtos.FeatureNode node : FeatureGraphChecks.findNodes(graph, span)) {
+      List<FeatureNode> typeNodes = graph.successors(node, EdgeType.HAS_TYPE)
+          .stream()
+          .limit(2)
+          .collect(Collectors.toList());
+
+      if (typeNodes.size() > 0) {
+        return typeNodes.get(0);
+      }
+    }
+    throw new AssertionError("Could not find type node");
   }
 }

--- a/src/main/java/uk/ac/cam/acr31/features/javac/testing/FeatureGraphChecks.java
+++ b/src/main/java/uk/ac/cam/acr31/features/javac/testing/FeatureGraphChecks.java
@@ -28,10 +28,14 @@ import uk.ac.cam.acr31.features.javac.proto.GraphProtos.FeatureNode;
 
 public class FeatureGraphChecks {
 
+  public static Set<FeatureNode> findNodes(FeatureGraph graph, SourceSpan span) {
+    return graph.findNode(span.start(), span.end());
+  }
+
   public static FeatureEdge edgeBetween(
       FeatureGraph graph, SourceSpan source, SourceSpan destination, EdgeType edgeType) {
-    Set<FeatureNode> sourceNodes = graph.findNode(source.start(), source.end());
-    Set<FeatureNode> destinationNodes = graph.findNode(destination.start(), destination.end());
+    Set<FeatureNode> sourceNodes = findNodes(graph, source);
+    Set<FeatureNode> destinationNodes = findNodes(graph, destination);
     for (FeatureNode sourceNode : sourceNodes) {
       for (FeatureNode destinationNode : destinationNodes) {
         Optional<FeatureEdge> edge =

--- a/src/main/protobuf/graph.proto
+++ b/src/main/protobuf/graph.proto
@@ -36,6 +36,7 @@ message FeatureNode {
         SYMBOL_TYP = 10;
         SYMBOL_VAR = 11;
         SYMBOL_MTH = 12;
+        TYPE = 13;
     }
 
     optional int64 id = 1;
@@ -64,6 +65,7 @@ message FeatureEdge {
         LAST_LEXICAL_USE = 12;
         COMMENT = 13;
         ASSOCIATED_SYMBOL = 14;
+        HAS_TYPE = 15;
     }
 
     optional int64 sourceId = 1;

--- a/src/main/protobuf/graph.proto
+++ b/src/main/protobuf/graph.proto
@@ -66,6 +66,7 @@ message FeatureEdge {
         COMMENT = 13;
         ASSOCIATED_SYMBOL = 14;
         HAS_TYPE = 15;
+        ASSIGNABLE_TO = 16;
     }
 
     optional int64 sourceId = 1;

--- a/src/test/java/uk/ac/cam/acr31/features/javac/AssignabilityAnalysisTest.java
+++ b/src/test/java/uk/ac/cam/acr31/features/javac/AssignabilityAnalysisTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright © 2019 Henry Mercer (henry.mercer@me.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.ac.cam.acr31.features.javac;
+
+import static junit.framework.TestCase.*;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import uk.ac.cam.acr31.features.javac.graph.FeatureGraph;
+import uk.ac.cam.acr31.features.javac.proto.GraphProtos;
+import uk.ac.cam.acr31.features.javac.proto.GraphProtos.FeatureEdge.EdgeType;
+import uk.ac.cam.acr31.features.javac.testing.FeatureGraphChecks;
+import uk.ac.cam.acr31.features.javac.testing.SourceSpan;
+import uk.ac.cam.acr31.features.javac.testing.TestCompilation;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@RunWith(JUnit4.class)
+public class AssignabilityAnalysisTest {
+  @Test
+  public void assignabilityAnalysis_doesNotIntroduceAssignableEdgeBetweenUnassignableClasses() {
+    // ARRANGE
+    TestCompilation compilation =
+        TestCompilation.compile(
+            "Test.java", //
+            "public class Test {",
+            "  static class A {}",
+            "  static class B {}",
+            "  private static void f(A a, B b) {",
+            "  }",
+            "  public static void main(String[] args) {",
+            "    f(new A(), new B());",
+            "  }",
+            "}");
+    SourceSpan arg1 = compilation.sourceSpan("new A()");
+    SourceSpan arg2 = compilation.sourceSpan("new B()");
+
+    // ACT
+    FeatureGraph graph =
+        FeaturePlugin.createFeatureGraph(compilation.compilationUnit(), compilation.context());
+
+    // ASSERT
+    GraphProtos.FeatureNode arg1TypeNode = FeatureGraphChecks.findAssociatedTypeNode(graph, arg1);
+    GraphProtos.FeatureNode arg2TypeNode = FeatureGraphChecks.findAssociatedTypeNode(graph, arg2);
+    assertNotNull(arg1TypeNode);
+    assertNotNull(arg2TypeNode);
+    assertFalse(
+        "A shouldn't be assignable to B",
+        FeatureGraphChecks.isEdgeBetween(graph, arg1TypeNode, arg2TypeNode, EdgeType.ASSIGNABLE_TO));
+    assertFalse(
+        "B shouldn't be assignable to A",
+        FeatureGraphChecks.isEdgeBetween(graph, arg2TypeNode, arg1TypeNode, EdgeType.ASSIGNABLE_TO));
+  }
+
+  @Test
+  public void assignabilityAnalysis_doesNotIntroduceAssignableEdgeBetweenAssignableClasses() {
+    // ARRANGE
+    TestCompilation compilation =
+        TestCompilation.compile(
+            "Test.java", //
+            "public class Test {",
+            "  static class A {}",
+            "  static class B extends A {}",
+            "  private static void f(A a, B b) {",
+            "  }",
+            "  public static void main(String[] args) {",
+            "    f(new A(), new B());",
+            "  }",
+            "}");
+    SourceSpan arg1 = compilation.sourceSpan("new A()");
+    SourceSpan arg2 = compilation.sourceSpan("new B()");
+
+    // ACT
+    FeatureGraph graph =
+        FeaturePlugin.createFeatureGraph(compilation.compilationUnit(), compilation.context());
+
+    // ASSERT
+    GraphProtos.FeatureNode arg1TypeNode = FeatureGraphChecks.findAssociatedTypeNode(graph, arg1);
+    GraphProtos.FeatureNode arg2TypeNode = FeatureGraphChecks.findAssociatedTypeNode(graph, arg2);
+    assertNotNull(arg1TypeNode);
+    assertNotNull(arg2TypeNode);
+    assertFalse(
+        "A shouldn't be assignable to B",
+        FeatureGraphChecks.isEdgeBetween(graph, arg1TypeNode, arg2TypeNode, EdgeType.ASSIGNABLE_TO));
+    assertTrue(
+        "B should be assignable to A",
+        FeatureGraphChecks.isEdgeBetween(graph, arg2TypeNode, arg1TypeNode, EdgeType.ASSIGNABLE_TO));
+  }
+}

--- a/src/test/java/uk/ac/cam/acr31/features/javac/TypeScannerTest.java
+++ b/src/test/java/uk/ac/cam/acr31/features/javac/TypeScannerTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright © 2019 Henry Mercer (henry.mercer@me.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.ac.cam.acr31.features.javac;
+
+import static junit.framework.TestCase.*;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import uk.ac.cam.acr31.features.javac.graph.FeatureGraph;
+import uk.ac.cam.acr31.features.javac.proto.GraphProtos;
+import uk.ac.cam.acr31.features.javac.proto.GraphProtos.FeatureEdge.EdgeType;
+import uk.ac.cam.acr31.features.javac.testing.FeatureGraphChecks;
+import uk.ac.cam.acr31.features.javac.testing.SourceSpan;
+import uk.ac.cam.acr31.features.javac.testing.TestCompilation;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RunWith(JUnit4.class)
+public class TypeScannerTest {
+  @Test
+  public void typeScanner_createsTypeNodesAndEdgesForIntVariableExp() {
+    // ARRANGE
+    TestCompilation compilation =
+        TestCompilation.compile(
+            "Test.java", //
+            "public class Test {",
+            "  public static void main(String[] args) {",
+            "    int a = 4;",
+            "  }",
+            "}");
+    SourceSpan type = compilation.sourceSpan("int");
+    SourceSpan initializer = compilation.sourceSpan("4");
+
+    // ACT
+    FeatureGraph graph =
+        FeaturePlugin.createFeatureGraph(compilation.compilationUnit(), compilation.context());
+
+    // ASSERT
+    GraphProtos.FeatureNode typeNode = findTypeNode(graph, type);
+    GraphProtos.FeatureNode initializerNode = findTypeNode(graph, initializer);
+    assertSame("typeNode and initializerNode should be associated with the same type node in the graph",
+        typeNode,
+        initializerNode);
+    assertNotNull(typeNode);
+    assertEquals("int", typeNode.getContents());
+  }
+
+  @Test
+  public void typeScanner_createsTypeNodesAndEdgesForIntAssignmentExp() {
+    // ARRANGE
+    TestCompilation compilation =
+        TestCompilation.compile(
+            "Test.java", //
+            "public class Test {",
+            "  public static void main(String[] args) {",
+            "    int a = 4;",
+            "    a = 5;",
+            "  }",
+            "}");
+    SourceSpan variable = compilation.sourceSpan("a", " = 5");
+    SourceSpan newExpression = compilation.sourceSpan("5");
+
+    // ACT
+    FeatureGraph graph =
+        FeaturePlugin.createFeatureGraph(compilation.compilationUnit(), compilation.context());
+
+    // ASSERT
+    GraphProtos.FeatureNode variableNode = findTypeNode(graph, variable);
+    GraphProtos.FeatureNode newExpressionNode = findTypeNode(graph, newExpression);
+    assertSame("variableNode and newExpressionNode should be associated with the same type node in the graph",
+        variableNode,
+        newExpressionNode);
+    assertNotNull(variableNode);
+    assertEquals("int", variableNode.getContents());
+  }
+
+  @Test
+  public void typeScanner_createsTypeNodesAndEdgesForCallWithSameTypeArgs() {
+    // ARRANGE
+    TestCompilation compilation =
+        TestCompilation.compile(
+            "Test.java", //
+            "public class Test {",
+            "  private static void f(int a, int b) {",
+            "  }",
+            "  public static void main(String[] args) {",
+            "    f(1 + 2, 3 + 4);",
+            "  }",
+            "}");
+    SourceSpan arg1 = compilation.sourceSpan("1 + 2");
+    SourceSpan arg2 = compilation.sourceSpan("3 + 4");
+
+    // ACT
+    FeatureGraph graph =
+        FeaturePlugin.createFeatureGraph(compilation.compilationUnit(), compilation.context());
+
+    // ASSERT
+    GraphProtos.FeatureNode arg1TypeNode = findTypeNode(graph, arg1);
+    GraphProtos.FeatureNode arg2TypeNode = findTypeNode(graph, arg2);
+    assertSame("arg1Node and arg2Node should be associated with the same type node in the graph",
+        arg1TypeNode,
+        arg2TypeNode);
+    assertNotNull(arg1TypeNode);
+    assertEquals("int", arg1TypeNode.getContents());
+  }
+
+  @Test
+  public void typeScanner_createsTypeNodesAndEdgesForCallWithDifferentTypeArgs() {
+    // ARRANGE
+    TestCompilation compilation =
+        TestCompilation.compile(
+            "Test.java", //
+            "public class Test {",
+            "  static class A {}",
+            "  static class B {}",
+            "  private static void f(A a, B b) {",
+            "  }",
+            "  public static void main(String[] args) {",
+            "    f(new A(), new B());",
+            "  }",
+            "}");
+    SourceSpan arg1 = compilation.sourceSpan("new A()");
+    SourceSpan arg2 = compilation.sourceSpan("new B()");
+
+    // ACT
+    FeatureGraph graph =
+        FeaturePlugin.createFeatureGraph(compilation.compilationUnit(), compilation.context());
+
+    // ASSERT
+    GraphProtos.FeatureNode arg1TypeNode = findTypeNode(graph, arg1);
+    GraphProtos.FeatureNode arg2TypeNode = findTypeNode(graph, arg2);
+    assertNotNull(arg1TypeNode);
+    assertNotNull(arg2TypeNode);
+    assertEquals("Test.A", arg1TypeNode.getContents());
+    assertEquals("Test.B", arg2TypeNode.getContents());
+  }
+
+  private GraphProtos.FeatureNode findTypeNode(FeatureGraph graph, SourceSpan span) {
+    for (GraphProtos.FeatureNode node : FeatureGraphChecks.findNodes(graph, span)) {
+      List<GraphProtos.FeatureNode> typeNodes = graph.successors(node, EdgeType.HAS_TYPE)
+          .stream()
+          .limit(2)
+          .collect(Collectors.toList());
+
+      if (typeNodes.size() > 0) {
+        return typeNodes.get(0);
+      }
+    }
+    fail("Could not find type node");
+    return null;
+  }
+}

--- a/src/test/java/uk/ac/cam/acr31/features/javac/TypeScannerTest.java
+++ b/src/test/java/uk/ac/cam/acr31/features/javac/TypeScannerTest.java
@@ -52,8 +52,8 @@ public class TypeScannerTest {
         FeaturePlugin.createFeatureGraph(compilation.compilationUnit(), compilation.context());
 
     // ASSERT
-    GraphProtos.FeatureNode typeNode = findTypeNode(graph, type);
-    GraphProtos.FeatureNode initializerNode = findTypeNode(graph, initializer);
+    GraphProtos.FeatureNode typeNode = FeatureGraphChecks.findAssociatedTypeNode(graph, type);
+    GraphProtos.FeatureNode initializerNode = FeatureGraphChecks.findAssociatedTypeNode(graph, initializer);
     assertSame("typeNode and initializerNode should be associated with the same type node in the graph",
         typeNode,
         initializerNode);
@@ -81,8 +81,8 @@ public class TypeScannerTest {
         FeaturePlugin.createFeatureGraph(compilation.compilationUnit(), compilation.context());
 
     // ASSERT
-    GraphProtos.FeatureNode variableNode = findTypeNode(graph, variable);
-    GraphProtos.FeatureNode newExpressionNode = findTypeNode(graph, newExpression);
+    GraphProtos.FeatureNode variableNode = FeatureGraphChecks.findAssociatedTypeNode(graph, variable);
+    GraphProtos.FeatureNode newExpressionNode = FeatureGraphChecks.findAssociatedTypeNode(graph, newExpression);
     assertSame("variableNode and newExpressionNode should be associated with the same type node in the graph",
         variableNode,
         newExpressionNode);
@@ -111,8 +111,8 @@ public class TypeScannerTest {
         FeaturePlugin.createFeatureGraph(compilation.compilationUnit(), compilation.context());
 
     // ASSERT
-    GraphProtos.FeatureNode arg1TypeNode = findTypeNode(graph, arg1);
-    GraphProtos.FeatureNode arg2TypeNode = findTypeNode(graph, arg2);
+    GraphProtos.FeatureNode arg1TypeNode = FeatureGraphChecks.findAssociatedTypeNode(graph, arg1);
+    GraphProtos.FeatureNode arg2TypeNode = FeatureGraphChecks.findAssociatedTypeNode(graph, arg2);
     assertSame("arg1Node and arg2Node should be associated with the same type node in the graph",
         arg1TypeNode,
         arg2TypeNode);
@@ -143,26 +143,11 @@ public class TypeScannerTest {
         FeaturePlugin.createFeatureGraph(compilation.compilationUnit(), compilation.context());
 
     // ASSERT
-    GraphProtos.FeatureNode arg1TypeNode = findTypeNode(graph, arg1);
-    GraphProtos.FeatureNode arg2TypeNode = findTypeNode(graph, arg2);
+    GraphProtos.FeatureNode arg1TypeNode = FeatureGraphChecks.findAssociatedTypeNode(graph, arg1);
+    GraphProtos.FeatureNode arg2TypeNode = FeatureGraphChecks.findAssociatedTypeNode(graph, arg2);
     assertNotNull(arg1TypeNode);
     assertNotNull(arg2TypeNode);
     assertEquals("Test.A", arg1TypeNode.getContents());
     assertEquals("Test.B", arg2TypeNode.getContents());
-  }
-
-  private GraphProtos.FeatureNode findTypeNode(FeatureGraph graph, SourceSpan span) {
-    for (GraphProtos.FeatureNode node : FeatureGraphChecks.findNodes(graph, span)) {
-      List<GraphProtos.FeatureNode> typeNodes = graph.successors(node, EdgeType.HAS_TYPE)
-          .stream()
-          .limit(2)
-          .collect(Collectors.toList());
-
-      if (typeNodes.size() > 0) {
-        return typeNodes.get(0);
-      }
-    }
-    fail("Could not find type node");
-    return null;
   }
 }


### PR DESCRIPTION
Adds type nodes to the feature graph and edges between type nodes indicating whether the source type is assignable to the destination type.

Currently type nodes are added for variable statements, assignment statements, arguments of method invocations, and binary expressions.  This might be something we want to expand.