### PR TITLE
Fix incorrect symbol->identifier edges

### DIFF
--- a/extractor/src/main/java/uk/ac/cam/acr31/features/javac/syntactic/SymbolScanner.java
+++ b/extractor/src/main/java/uk/ac/cam/acr31/features/javac/syntactic/SymbolScanner.java
@@ -53,50 +53,58 @@ public class SymbolScanner extends TreeScanner<Void, Void> {
 
   @Override
   public Void visitClass(ClassTree node, Void ignored) {
+    Void result = super.visitClass(node, ignored);
     addNode(node);
-    return super.visitClass(node, ignored);
+    return result;
   }
 
   @Override
   public Void visitNewClass(NewClassTree node, Void ignored) {
+    Void result = super.visitNewClass(node, ignored);
     addNode(node);
-    return super.visitNewClass(node, ignored);
+    return result;
   }
 
   @Override
   public Void visitMethod(MethodTree node, Void ignored) {
+    Void result = super.visitMethod(node, ignored);
     addNode(node);
-    return super.visitMethod(node, ignored);
+    return result;
   }
 
   @Override
   public Void visitMethodInvocation(MethodInvocationTree node, Void ignored) {
+    Void result = super.visitMethodInvocation(node, ignored);
     addNode(node);
-    return super.visitMethodInvocation(node, ignored);
+    return result;
   }
 
   @Override
   public Void visitIdentifier(IdentifierTree node, Void ignored) {
+    Void result = super.visitIdentifier(node, ignored);
     addNode(node);
-    return super.visitIdentifier(node, ignored);
+    return result;
   }
 
   @Override
   public Void visitMemberSelect(MemberSelectTree node, Void ignored) {
+    Void result = super.visitMemberSelect(node, ignored);
     addNode(node);
-    return super.visitMemberSelect(node, ignored);
+    return result;
   }
 
   @Override
   public Void visitVariable(VariableTree node, Void ignored) {
+    Void result = super.visitVariable(node, ignored);
     addNode(node);
-    return super.visitVariable(node, ignored);
+    return result;
   }
 
   @Override
   public Void visitPackage(PackageTree node, Void ignored) {
+    Void result = super.visitPackage(node, ignored);
     addNode(node);
-    return super.visitPackage(node, ignored);
+    return result;
   }
 
   private void addNode(Tree node) {


### PR DESCRIPTION
This possibly fixes both issue #10 and #11. All existing tests pass, but I didn't add any either, so I might just be adding different bugs :) I eyeballed about 10 graphs which were previously problematic (including the ones mentioned in issues #10 and #11) and they look ok now.

Calling `super.visitClass` before `addNode` in `SymbolScanner` caused nodes closer to the root of the AST to be assigned a symbol first, and because the IDENTIFIER_TOKEN corresponding to each AST subtree is found via BFS, it sometimes arrived at the wrong identifier first (e.g. a AST_ELEMENT(METHOD_INVOCATION) might have been assigned an IDENTIFIER_TOKEN corresponding to a parameter, rather than the method name). 

By reversing the order of `super.visitClass` and `addNode`, the `TreeVisitor` assigns symbols leaf-to-root, and we guarantee that symbols for smaller AST subtrees are attached first. The BFS which searches for the IDENTIFIER_TOKEN corresponding to an AST node is then limited to token nodes which haven't been attached to a symbol from any of the node's sub-trees yet (e.g. a method's parameter symbols will be attached before the method's symbol, which will be attached before package symbols).